### PR TITLE
Showcase: casino table UI and interactive play vs dealer

### DIFF
--- a/demos/leduc/.gitignore
+++ b/demos/leduc/.gitignore
@@ -1,0 +1,16 @@
+# Build artifacts
+build/
+*.so
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+
+# Training data (large — download separately or copy from Downloads)
+data/hands.csv
+data/players.csv
+
+# Trained model cache (auto-regenerated from hands.csv)
+data/classifier_model.pkl

--- a/demos/leduc/src/showcase/app.py
+++ b/demos/leduc/src/showcase/app.py
@@ -24,6 +24,11 @@ from demo_vs_tight import (
     build_tight_strategy_vector, compute_exploit_strategy,
     JACK, QUEEN, KING,
 )
+from classifier import (
+    OpponentClassifier, ActionTracker,
+    LABEL_NAMES, LABEL_COLORS, LABEL_ICONS,
+    load_classifier,
+)
 
 # ─────────────────────────────────────────────────────────────
 # Opponent profiles
@@ -267,12 +272,21 @@ if "trained" not in st.session_state:
     st.session_state.sim_done     = False
     st.session_state.last_opponent = None
     st.session_state.play_bankroll = 0
-    st.session_state.play_hands = 0
+    st.session_state.play_hands    = 0
+    st.session_state.play_wins     = 0
     st.session_state.play_hand_active = False
-    st.session_state.play_h = None
-    st.session_state.play_cards = None
-    st.session_state.play_log = []
-    st.session_state.play_last_delta = 0
+    st.session_state.play_h        = None
+    st.session_state.play_cards    = None
+    st.session_state.play_log      = []
+    st.session_state.play_last_delta  = 0
+    st.session_state.table_rng_seed   = 0
+    st.session_state.last_showdown    = None   # persists after hand ends
+    # Layer 2: opponent classifier
+    st.session_state.clf            = None   # OpponentClassifier (loaded lazily)
+    st.session_state.tracker        = ActionTracker()
+    st.session_state.clf_result     = None   # (label, confidence, probs) or None
+    st.session_state.auto_opponent  = None   # detected profile driving dealer strategy
+    st.session_state.detected_br    = None   # cached BRSolver strategy for detected profile
 
 # Reset if opponent changed
 if st.session_state.last_opponent != opponent:
@@ -285,13 +299,17 @@ if st.session_state.last_opponent != opponent:
 
 
 def _new_table_hand(rng):
-    p0 = int(rng.integers(0, 3))
-    p1 = int(rng.integers(0, 3))
-    comm = int(rng.integers(0, 3))
-    st.session_state.play_h = p0 * 8
+    # Deal 3 distinct ranks (same rank can't appear twice — no pair without community match)
+    ranks = rng.choice(3, size=3, replace=False).tolist()
+    p0, p1, comm = int(ranks[0]), int(ranks[1]), int(ranks[2])
+    st.session_state.play_h     = p0 * 8
     st.session_state.play_cards = [p0, p1, comm]
-    st.session_state.play_log = ["New hand dealt."]
+    st.session_state.play_log   = ["New hand dealt."]
     st.session_state.play_hand_active = True
+    # Advance the seed so each deal is fresh
+    st.session_state.table_rng_seed += 1
+    # Start tracking this hand for the classifier
+    st.session_state.tracker.start_hand()
 
 
 def _move_label(h, action):
@@ -303,27 +321,72 @@ def _move_label(h, action):
 
 
 def _apply_table_action(action):
-    h = st.session_state.play_h
+    h     = st.session_state.play_h
     cards = st.session_state.play_cards
-    cur = _stm(h)
+    cur   = _stm(h)
     actor = "You" if cur == 0 else "Dealer"
     label = _move_label(h, action)
     st.session_state.play_log.append(f"{actor}: {label}")
+
+    # Record the judge's action for classifier training
+    if cur == 0:
+        st.session_state.tracker.record_action(
+            action_label=label,
+            raises_before=_raises(h),
+            round_id=_bet_round(h) + 1,
+        )
 
     if _ends_hand(h, action):
         pay = _payout(h, action, cards[1 - cur])
         user_delta = pay if cur == 0 else -pay
         st.session_state.play_last_delta = int(user_delta)
-        st.session_state.play_bankroll += int(user_delta)
-        st.session_state.play_hands += 1
+        st.session_state.play_bankroll  += int(user_delta)
+        st.session_state.play_hands     += 1
+        if user_delta > 0:
+            st.session_state.play_wins  += 1
+        # Showdown = hand ends without a fold
+        went_to_showdown = (label != "Fold")
+        st.session_state.tracker.end_hand(went_to_showdown)
+        # Re-classify after every completed hand
+        _update_classification()
         st.session_state.play_hand_active = False
         st.session_state.play_log.append(
             f"Hand over. You {'won' if user_delta > 0 else 'lost' if user_delta < 0 else 'pushed'} {user_delta:+d} chips."
         )
+        # Persist showdown info so it stays visible after rerun
+        st.session_state.last_showdown = {
+            "cards": list(cards),   # [p0, p1, comm]
+            "delta": int(user_delta),
+            "showdown": went_to_showdown,
+        }
         return
 
     ns = _next_stm(h, action)
     st.session_state.play_h = _next_hash(h, action, cards[2], cards[ns])
+
+
+def _update_classification() -> None:
+    """Run the classifier after a hand completes and cache the result."""
+    clf = st.session_state.get("clf")
+    if clf is None:
+        # Lazy-load (blocks once, ~1–2 s on first hand)
+        clf = load_classifier()
+        st.session_state.clf = clf
+    result = clf.predict(st.session_state.tracker)
+    if result is not None:
+        label, conf, probs = result
+        st.session_state.clf_result    = (label, conf, probs)
+        # After 5 hands with ≥ 70 % confidence, auto-switch dealer opponent profile.
+        # Recompute the BRSolver for the new detected profile only when it changes.
+        if st.session_state.tracker.n_hands >= 5 and conf >= 0.70:
+            prev = st.session_state.get("auto_opponent")
+            st.session_state.auto_opponent = label
+            if label != prev and st.session_state.br_strategy is not None:
+                opp_vec = build_opponent_vector(label)
+                br_live = BRSolver()
+                br_live.load_strategy(opp_vec)
+                br_live.compute(0)
+                st.session_state.detected_br = br_live.get_full_br_strategy()
 
 # ─────────────────────────────────────────────────────────────
 # Phase 1: Train GTO
@@ -538,83 +601,324 @@ else:
 # Phase 3: Play at the table
 # ─────────────────────────────────────────────────────────────
 st.divider()
-st.markdown("### Casino Table — Play vs Dealer")
+
+# ── Section header with architecture flow ─────────────────────
+st.markdown("""
+<div style='margin-bottom:0.6rem'>
+  <span style='color:#e8eaf0;font-size:1.3rem;font-weight:700'>🃏 Play the Dealer — Watch TiltStack Adapt</span><br>
+  <span style='color:#888fa8;font-size:0.88rem'>
+    Every hand you play is fed into the 3-layer pipeline in real time.
+  </span>
+</div>
+""", unsafe_allow_html=True)
 
 if not st.session_state.trained:
-    st.info("Train the model in Step 1 to unlock table play.")
+    st.info("Complete Step 1 (Train CFR+) first to unlock table play.")
 else:
-    rng_table = np.random.default_rng(int(time.time()) % (2**32 - 1))
+    rng_table   = np.random.default_rng(st.session_state.table_rng_seed)
+    dealer_mode = "Exploit" if st.session_state.br_strategy is not None else "GTO"
 
-    top_a, top_b, top_c = st.columns([2, 2, 3])
+    clf_result    = st.session_state.get("clf_result")
+    auto_opponent = st.session_state.get("auto_opponent")
+    n_tracked     = st.session_state.tracker.n_hands
+    LOCK_THRESHOLD = 5   # hands before strategy locks in
+
+    # ── Architecture pipeline display ─────────────────────────────────────────
+    # Always visible — shows what stage TiltStack is at right now.
+    L1_done  = st.session_state.trained
+    L2_done  = clf_result is not None
+    L2_locked = auto_opponent is not None
+    L3_done  = L2_locked
+
+    def _pipe_node(num, label, sublabel, done, locked=False, color="#4ecdc4"):
+        if locked:
+            bg, border, tc = "rgba(78,44,132,0.35)", "#7c3aed", "#c4b5fd"
+        elif done:
+            bg, border, tc = f"rgba(0,0,0,0.25)", f"{color}55", color
+        else:
+            bg, border, tc = "rgba(0,0,0,0.15)", "#2f3548", "#555d75"
+        icon = "✓" if (done and not locked) else ("🔒" if locked else "○")
+        return (
+            f"<div style='flex:1;background:{bg};border:1px solid {border};"
+            f"border-radius:10px;padding:0.6rem 0.8rem;text-align:center'>"
+            f"<div style='color:{tc};font-size:1.1rem;font-weight:700'>{icon} L{num}</div>"
+            f"<div style='color:{tc};font-size:0.82rem;font-weight:600;margin-top:2px'>{label}</div>"
+            f"<div style='color:#555d75;font-size:0.72rem;margin-top:2px'>{sublabel}</div>"
+            f"</div>"
+        )
+
+    l2_sublabel = (
+        f"Locked: {auto_opponent}" if L2_locked
+        else (f"Reading… {n_tracked}/{LOCK_THRESHOLD} hands" if L2_done else f"{n_tracked}/3 hands")
+    )
+    l3_sublabel = f"Exploiting {auto_opponent}" if L3_done else "Waiting for L2"
+
+    pipe_html = (
+        "<div style='display:flex;gap:0.5rem;align-items:stretch;margin-bottom:0.9rem'>"
+        + _pipe_node(1, "CFR+ Nash",   "Equilibrium trained",      L1_done,  color="#4ecdc4")
+        + "<div style='display:flex;align-items:center;color:#2f3548;font-size:1.2rem;padding:0 2px'>→</div>"
+        + _pipe_node(2, "LSTM Classify", l2_sublabel,              L2_done,  L2_locked, color="#f5d46d")
+        + "<div style='display:flex;align-items:center;color:#2f3548;font-size:1.2rem;padding:0 2px'>→</div>"
+        + _pipe_node(3, "BRSolver",    l3_sublabel,                L3_done,  color="#ff6b6b")
+        + "</div>"
+    )
+    st.markdown(pipe_html, unsafe_allow_html=True)
+
+    # ── Classifier confidence panel (shows from hand 1) ───────────────────────
+    if n_tracked == 0 and not st.session_state.play_hand_active:
+        st.markdown(
+            "<div style='background:rgba(245,212,109,0.06);border:1px solid #3a3010;"
+            "border-radius:10px;padding:0.65rem 1rem;margin-bottom:0.7rem;"
+            "color:#888fa8;font-size:0.88rem'>"
+            "🧠 <strong style='color:#c8cad8'>Layer 2 will read your play style</strong> — "
+            "raise aggressively, call everything, or play tight. "
+            "After 3 hands it produces a live classification. After 5 hands it locks in and "
+            "Layer 3 (BRSolver) recomputes an exploit strategy specifically for you."
+            "</div>",
+            unsafe_allow_html=True,
+        )
+    elif clf_result is not None:
+        det_label, det_conf, det_probs = clf_result
+        det_idx   = LABEL_NAMES.index(det_label)
+        det_color = LABEL_COLORS[det_idx]
+        det_icon  = LABEL_ICONS[det_idx]
+
+        # Build confidence bar rows
+        bars_html = ""
+        for i, (lname, lcolor) in enumerate(zip(LABEL_NAMES, LABEL_COLORS)):
+            pct  = det_probs[i] * 100
+            bold = "font-weight:700;" if i == det_idx else ""
+            bars_html += (
+                f"<div style='display:flex;align-items:center;gap:0.5rem;margin-bottom:4px'>"
+                f"<div style='color:{lcolor};font-size:0.75rem;width:4.5rem;{bold}'>{lname}</div>"
+                f"<div style='flex:1;background:#1e2130;border-radius:4px;height:8px'>"
+                f"<div style='width:{pct:.0f}%;background:{lcolor};height:8px;border-radius:4px'></div>"
+                f"</div>"
+                f"<div style='color:{lcolor};font-size:0.75rem;width:2.5rem;text-align:right;{bold}'>{pct:.0f}%</div>"
+                f"</div>"
+            )
+
+        status_line = (
+            f"<span style='color:#7c3aed;font-weight:700'>🔒 LOCKED IN — Strategy updated for you</span>"
+            if L2_locked else
+            f"<span style='color:#888fa8'>Confidence building… {n_tracked}/{LOCK_THRESHOLD} hands ({det_conf*100:.0f}% confidence needed: 70%)</span>"
+        )
+
+        clf_html = (
+            f"<div style='background:rgba(0,0,0,0.3);border:1px solid {det_color}55;"
+            f"border-radius:12px;padding:0.8rem 1rem;margin-bottom:0.8rem'>"
+            f"<div style='display:flex;align-items:center;gap:0.5rem;margin-bottom:0.5rem'>"
+            f"<span style='font-size:1.6rem'>{det_icon}</span>"
+            f"<div>"
+            f"<div style='color:#9ca3bc;font-size:0.7rem;text-transform:uppercase;letter-spacing:0.1em'>Layer 2 · LSTM Classifier</div>"
+            f"<div style='color:{det_color};font-size:1.15rem;font-weight:700'>Reading you as: {det_label}</div>"
+            f"</div>"
+            f"<div style='margin-left:auto;font-size:0.78rem'>{status_line}</div>"
+            f"</div>"
+            f"{bars_html}"
+            f"</div>"
+        )
+        st.markdown(clf_html, unsafe_allow_html=True)
+
+        # Dramatic lock-in banner (fires once when auto_opponent first set)
+        if L2_locked and st.session_state.get("_lock_banner_shown") != auto_opponent:
+            st.session_state["_lock_banner_shown"] = auto_opponent
+            st.balloons()
+            st.success(
+                f"⚡ TiltStack identified you as **{auto_opponent}** — "
+                f"BRSolver recomputed. The dealer is now exploiting your specific tendencies."
+            )
+    else:
+        # 1–2 hands in: show a progress bar so judges see something happening
+        pct_done = n_tracked / 3
+        st.markdown(
+            f"<div style='background:rgba(0,0,0,0.25);border:1px solid #2f3548;"
+            f"border-radius:10px;padding:0.65rem 1rem;margin-bottom:0.7rem'>"
+            f"<div style='color:#9ca3bc;font-size:0.72rem;text-transform:uppercase;"
+            f"letter-spacing:0.08em;margin-bottom:6px'>Layer 2 · Building profile…</div>"
+            f"<div style='background:#1e2130;border-radius:4px;height:10px;margin-bottom:6px'>"
+            f"<div style='width:{pct_done*100:.0f}%;background:linear-gradient(90deg,#f5d46d,#d4af37);"
+            f"height:10px;border-radius:4px;transition:width 0.4s'></div></div>"
+            f"<div style='color:#888fa8;font-size:0.8rem'>"
+            f"{n_tracked} / 3 hands · Play more to unlock classification</div>"
+            f"</div>",
+            unsafe_allow_html=True,
+        )
+
+    # ── Metrics row ────────────────────────────────────────────────────────────
+    top_a, top_b, top_c, top_d = st.columns([2, 2, 2, 2])
     with top_a:
-        st.metric("Your Bankroll", f"{st.session_state.play_bankroll:+d} chips")
+        delta_chips = st.session_state.play_last_delta
+        st.metric("Your Bankroll",
+                  f"{st.session_state.play_bankroll:+d} chips",
+                  delta=f"{delta_chips:+d}" if st.session_state.play_hands > 0 else None)
     with top_b:
         st.metric("Hands Played", f"{st.session_state.play_hands}")
     with top_c:
-        st.caption("Classic heads-up Leduc table with clean casino styling.")
+        win_rate = (st.session_state.play_wins / st.session_state.play_hands * 100
+                    if st.session_state.play_hands > 0 else 0.0)
+        st.metric("Win Rate", f"{win_rate:.0f}%")
+    with top_d:
+        active_delta = "BRSolver exploit" if dealer_mode == "Exploit" else "Nash equilibrium"
+        if auto_opponent is not None:
+            active_delta = f"Exploiting **{auto_opponent}**"
+        st.metric("Dealer strategy", dealer_mode, delta=active_delta)
 
-    if not st.session_state.play_hand_active:
-        if st.button("Deal New Hand"):
+    # ── Persistent last showdown result ──────────────────────────────────────
+    # Shown above the deal button so judges always see the last result
+    # and know to press Deal again. Stays visible even after rerun.
+    last_sd = st.session_state.get("last_showdown")
+    if last_sd and not st.session_state.play_hand_active:
+        delta         = last_sd["delta"]
+        p_card        = CARD_LABELS[last_sd["cards"][0]]
+        d_card        = CARD_LABELS[last_sd["cards"][1]]
+        b_card        = CARD_LABELS[last_sd["cards"][2]]
+        outcome_color = "#4ecdc4" if delta > 0 else ("#ef4444" if delta < 0 else "#888fa8")
+        outcome_word  = "WIN ✓" if delta > 0 else ("LOSS ✗" if delta < 0 else "PUSH")
+        st.markdown(
+            f"<div style='background:rgba(0,0,0,0.3);border:1px solid {outcome_color}55;"
+            f"border-radius:10px;padding:0.8rem 1rem;margin-bottom:0.6rem;"
+            f"display:flex;align-items:center;justify-content:space-between'>"
+            f"<div>"
+            f"<div style='color:#9ca3bc;font-size:0.72rem;text-transform:uppercase;"
+            f"letter-spacing:0.08em'>Last hand</div>"
+            f"<div style='color:#e8eaf0;font-size:0.95rem;margin-top:2px'>"
+            f"You <strong>{p_card}</strong> · Dealer <strong>{d_card}</strong> · Board <strong>{b_card}</strong>"
+            f"</div>"
+            f"</div>"
+            f"<div style='text-align:right'>"
+            f"<div style='color:{outcome_color};font-size:1.3rem;font-weight:900'>{outcome_word}</div>"
+            f"<div style='color:{outcome_color};font-size:0.95rem'>{delta:+d} chips</div>"
+            f"</div>"
+            f"</div>",
+            unsafe_allow_html=True,
+        )
+
+    # ── Deal / Reset — always visible ────────────────────────────────────────
+    col_deal, col_reset = st.columns([4, 1])
+    with col_deal:
+        hand_active = st.session_state.play_hand_active
+        btn_label   = "⏳  Hand in progress…" if hand_active else "🃏  Deal New Hand"
+        if st.button(btn_label, disabled=hand_active, use_container_width=True):
             _new_table_hand(rng_table)
             st.rerun()
-    else:
-        h = st.session_state.play_h
-        cards = st.session_state.play_cards
-        round_id = _bet_round(h) + 1
-        pot_scale = 2 + 2 * _raises(h) + (4 if _bet_round(h) == 1 else 0)
+    with col_reset:
+        if st.button("↺  Reset", use_container_width=True, disabled=hand_active):
+            st.session_state.play_bankroll    = 0
+            st.session_state.play_hands       = 0
+            st.session_state.play_wins        = 0
+            st.session_state.play_last_delta  = 0
+            st.session_state.play_hand_active = False
+            st.session_state.table_rng_seed   = 0
+            st.session_state.last_showdown    = None
+            st.session_state.tracker.reset()
+            st.session_state.clf_result       = None
+            st.session_state.auto_opponent    = None
+            st.session_state.detected_br      = None
+            st.session_state.pop("_lock_banner_shown", None)
+            st.rerun()
+
+    # ── Active hand ────────────────────────────────────────────────────────────
+    if st.session_state.play_hand_active:
+        h         = st.session_state.play_h
+        cards     = st.session_state.play_cards
+        round_id  = _bet_round(h) + 1
+        pot_chips = 2 + 2 * _raises(h) + (4 if _bet_round(h) == 1 else 0)
 
         table_left, table_right = st.columns([3, 2])
         with table_left:
-            board = CARD_LABELS[cards[2]] if _bet_round(h) == 1 else "?"
+            board_card = CARD_LABELS[cards[2]] if _bet_round(h) == 1 else "—"
+            dealer_tag = (
+                f"<span style='font-size:0.7rem;color:#7c3aed;margin-left:6px'>"
+                f"🔒 exploit</span>"
+                if auto_opponent else ""
+            )
             st.markdown(
-                (
-                    "<div class='casino-table'>"
-                    "<div class='casino-title'>Main Table</div>"
-                    f"<span class='chip-pill'>Round {round_id}</span>"
-                    f"<span class='chip-pill'>Pot Pressure: {pot_scale} chips</span>"
-                    "<p><strong>Your Card:</strong><span class='card-pill'>"
-                    f"{CARD_LABELS[cards[0]]}"
-                    "</span></p>"
-                    "<p><strong>Board:</strong><span class='card-pill'>"
-                    f"{board}"
-                    "</span></p>"
-                    "<p><strong>Dealer Card:</strong><span class='card-pill'>?</span></p>"
-                    "</div>"
-                ),
+                f"<div class='casino-table'>"
+                f"<div class='casino-title'>Main Table{dealer_tag}</div>"
+                f"<span class='chip-pill'>Round {round_id} of 2</span>"
+                f"<span class='chip-pill'>Pot: {pot_chips} chips</span>"
+                f"<div style='margin-top:0.7rem;display:flex;gap:1.2rem;align-items:center'>"
+                f"<div style='text-align:center'>"
+                f"<div style='color:#9ca3bc;font-size:0.72rem;margin-bottom:3px'>YOUR CARD</div>"
+                f"<div style='background:#f7f8fb;color:#1a1d27;font-size:1.8rem;font-weight:900;"
+                f"width:2.6rem;height:2.6rem;border-radius:8px;display:flex;"
+                f"align-items:center;justify-content:center'>{CARD_LABELS[cards[0]]}</div>"
+                f"</div>"
+                f"<div style='text-align:center'>"
+                f"<div style='color:#9ca3bc;font-size:0.72rem;margin-bottom:3px'>BOARD</div>"
+                f"<div style='background:#f7f8fb;color:#1a1d27;font-size:1.8rem;font-weight:900;"
+                f"width:2.6rem;height:2.6rem;border-radius:8px;display:flex;"
+                f"align-items:center;justify-content:center'>{board_card}</div>"
+                f"</div>"
+                f"<div style='text-align:center'>"
+                f"<div style='color:#9ca3bc;font-size:0.72rem;margin-bottom:3px'>DEALER</div>"
+                f"<div style='background:#2a2d3a;color:#555d75;font-size:1.8rem;font-weight:900;"
+                f"width:2.6rem;height:2.6rem;border-radius:8px;border:1px dashed #3a3d4a;"
+                f"display:flex;align-items:center;justify-content:center'>?</div>"
+                f"</div>"
+                f"</div>"
+                f"</div>",
                 unsafe_allow_html=True,
             )
 
         with table_right:
-            st.markdown("<div class='dealer-log'>", unsafe_allow_html=True)
-            st.markdown("**Dealer Log**")
-            for entry in st.session_state.play_log[-6:]:
-                st.caption(entry)
+            st.markdown(
+                "<div class='dealer-log'>"
+                "<div style='color:#9ca3bc;font-size:0.75rem;font-weight:600;"
+                "text-transform:uppercase;letter-spacing:0.08em;margin-bottom:6px'>"
+                "Action Log</div>",
+                unsafe_allow_html=True,
+            )
+            for entry in st.session_state.play_log[-7:]:
+                icon  = "▶" if entry.startswith("You") else ("◀" if entry.startswith("Dealer") else "·")
+                color = "#e8eaf0" if entry.startswith("You") else (
+                    "#ff6b6b" if entry.startswith("Dealer") else "#555d75")
+                st.markdown(
+                    f"<div style='color:{color};font-size:0.82rem;padding:2px 0'>{icon} {entry}</div>",
+                    unsafe_allow_html=True,
+                )
             st.markdown("</div>", unsafe_allow_html=True)
 
-        # Dealer acts automatically until it's your turn or the hand ends.
+        # Dealer auto-plays until judge's turn (or hand ends)
         guard = 0
         while st.session_state.play_hand_active and _stm(st.session_state.play_h) == 1 and guard < 6:
             guard += 1
-            h_bot = st.session_state.play_h
-            if st.session_state.br_strategy is not None:
+            h_bot       = st.session_state.play_h
+            detected_br = st.session_state.get("detected_br")
+            if detected_br is not None:
+                bot_action = _br_action(detected_br, h_bot, rng_table)
+            elif st.session_state.br_strategy is not None:
                 bot_action = _br_action(st.session_state.br_strategy, h_bot, rng_table)
             else:
                 bot_action = gto_action(st.session_state.strategies, h_bot, rng_table)
             _apply_table_action(bot_action)
+            st.session_state.table_rng_seed += 1
+            rng_table = np.random.default_rng(st.session_state.table_rng_seed)
 
+        # If the dealer's action ended the hand, rerun immediately so the
+        # "Last hand" result and re-enabled Deal button render correctly.
+        # Without this, Streamlit keeps the stale "Hand in progress…" UI.
+        if not st.session_state.play_hand_active:
+            st.rerun()
+
+        # Judge's move buttons
         if st.session_state.play_hand_active and _stm(st.session_state.play_h) == 0:
-            st.markdown("**Your move**")
             h_user = st.session_state.play_h
-            legal = _legal_moves(h_user)
+            legal  = _legal_moves(h_user)
+            st.markdown(
+                "<div style='color:#f5d46d;font-weight:600;font-size:0.9rem;"
+                "margin:0.5rem 0 0.3rem'>Your move:</div>",
+                unsafe_allow_html=True,
+            )
             cols = st.columns(len(legal))
+            action_labels = {
+                Action.CHECK: ("Fold" if _raises(h_user) > 0 else "Check"),
+                Action.BET:   ("Call"  if _raises(h_user) > 0 else "Bet"),
+                Action.RAISE: "Raise",
+            }
             for idx, action in enumerate(legal):
-                if cols[idx].button(_move_label(h_user, action), key=f"user_action_{idx}_{h_user}"):
+                lbl = action_labels[action]
+                if cols[idx].button(lbl, key=f"ua_{idx}_{h_user}", use_container_width=True):
                     _apply_table_action(action)
                     st.rerun()
-
-        if not st.session_state.play_hand_active:
-            cards = st.session_state.play_cards
-            st.success(
-                f"Showdown: You `{CARD_LABELS[cards[0]]}` vs Dealer `{CARD_LABELS[cards[1]]}` "
-                f"(Board `{CARD_LABELS[cards[2]]}`) · Result {st.session_state.play_last_delta:+d} chips"
-            )

--- a/demos/leduc/src/showcase/app.py
+++ b/demos/leduc/src/showcase/app.py
@@ -85,6 +85,12 @@ OPPONENT_DESC = {
     "Aggressive":    "Bets and raises constantly regardless of hand strength.",
 }
 
+CARD_LABELS = {
+    JACK: "J",
+    QUEEN: "Q",
+    KING: "K",
+}
+
 def build_opponent_vector(profile: str):
     if profile == "Tight":
         return build_tight_strategy_vector()
@@ -138,13 +144,14 @@ section.main > div                 { padding-top: 1.5rem; }
 
 /* Metric cards */
 [data-testid="metric-container"] {
-    background: #1a1d27;
-    border: 1px solid #2a2d3a;
-    border-radius: 10px;
+    background: linear-gradient(160deg, #161a24 0%, #131722 100%);
+    border: 1px solid #2f3548;
+    border-radius: 12px;
     padding: 1rem 1.2rem;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
 }
 [data-testid="stMetricValue"]  { color: #e8eaf0 !important; font-size: 2rem !important; }
-[data-testid="stMetricLabel"]  { color: #888fa8 !important; }
+[data-testid="stMetricLabel"]  { color: #9ca3bc !important; }
 [data-testid="stMetricDelta"]  { font-size: 1rem !important; }
 
 /* Progress bar color */
@@ -152,17 +159,65 @@ section.main > div                 { padding-top: 1.5rem; }
 
 /* Button */
 .stButton > button {
-    background: #4ecdc4; color: #0f1117;
+    background: linear-gradient(135deg, #d4af37 0%, #f5d46d 100%);
+    color: #11141e;
     font-weight: 700; border: none; border-radius: 8px;
     padding: 0.6rem 2rem; font-size: 1rem;
     width: 100%;
+    box-shadow: 0 4px 14px rgba(212, 175, 55, 0.28);
 }
-.stButton > button:hover { background: #38b2ac; }
+.stButton > button:hover { filter: brightness(0.96); }
 
 h1 { color: #e8eaf0 !important; }
 h2, h3 { color: #c8cad8 !important; }
 p, li  { color: #888fa8 !important; }
 label  { color: #c8cad8 !important; }
+
+.casino-table {
+    background: radial-gradient(circle at top, #214233 0%, #173328 42%, #111b18 100%);
+    border: 1px solid #785d1b;
+    border-radius: 18px;
+    padding: 1.1rem 1rem 0.9rem 1rem;
+    margin-bottom: 0.9rem;
+    box-shadow: inset 0 0 0 1px rgba(245, 212, 109, 0.12), 0 14px 30px rgba(0, 0, 0, 0.35);
+}
+.casino-title {
+    color: #f5d46d;
+    font-size: 0.92rem;
+    letter-spacing: 0.12em;
+    font-weight: 700;
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+}
+.card-pill {
+    display: inline-block;
+    min-width: 2.2rem;
+    text-align: center;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    margin-left: 0.35rem;
+    font-weight: 700;
+    background: #f7f8fb;
+    color: #1a1d27;
+}
+.chip-pill {
+    display: inline-block;
+    padding: 0.22rem 0.6rem;
+    border-radius: 999px;
+    margin-right: 0.35rem;
+    margin-top: 0.25rem;
+    border: 1px solid #9a7a25;
+    color: #f5d46d;
+    background: rgba(10, 13, 20, 0.42);
+    font-size: 0.84rem;
+}
+.dealer-log {
+    background: #141a26;
+    border: 1px solid #2f3548;
+    border-radius: 12px;
+    padding: 0.65rem 0.75rem;
+    min-height: 8rem;
+}
 </style>
 """, unsafe_allow_html=True)
 
@@ -211,6 +266,13 @@ if "trained" not in st.session_state:
     st.session_state.expl_hands   = []
     st.session_state.sim_done     = False
     st.session_state.last_opponent = None
+    st.session_state.play_bankroll = 0
+    st.session_state.play_hands = 0
+    st.session_state.play_hand_active = False
+    st.session_state.play_h = None
+    st.session_state.play_cards = None
+    st.session_state.play_log = []
+    st.session_state.play_last_delta = 0
 
 # Reset if opponent changed
 if st.session_state.last_opponent != opponent:
@@ -220,6 +282,48 @@ if st.session_state.last_opponent != opponent:
     st.session_state.expl_hands  = []
     st.session_state.br_strategy = None
     st.session_state.last_opponent = opponent
+
+
+def _new_table_hand(rng):
+    p0 = int(rng.integers(0, 3))
+    p1 = int(rng.integers(0, 3))
+    comm = int(rng.integers(0, 3))
+    st.session_state.play_h = p0 * 8
+    st.session_state.play_cards = [p0, p1, comm]
+    st.session_state.play_log = ["New hand dealt."]
+    st.session_state.play_hand_active = True
+
+
+def _move_label(h, action):
+    if action == Action.CHECK:
+        return "Fold" if _raises(h) > 0 else "Check"
+    if action == Action.BET:
+        return "Call"
+    return "Raise"
+
+
+def _apply_table_action(action):
+    h = st.session_state.play_h
+    cards = st.session_state.play_cards
+    cur = _stm(h)
+    actor = "You" if cur == 0 else "Dealer"
+    label = _move_label(h, action)
+    st.session_state.play_log.append(f"{actor}: {label}")
+
+    if _ends_hand(h, action):
+        pay = _payout(h, action, cards[1 - cur])
+        user_delta = pay if cur == 0 else -pay
+        st.session_state.play_last_delta = int(user_delta)
+        st.session_state.play_bankroll += int(user_delta)
+        st.session_state.play_hands += 1
+        st.session_state.play_hand_active = False
+        st.session_state.play_log.append(
+            f"Hand over. You {'won' if user_delta > 0 else 'lost' if user_delta < 0 else 'pushed'} {user_delta:+d} chips."
+        )
+        return
+
+    ns = _next_stm(h, action)
+    st.session_state.play_h = _next_hash(h, action, cards[2], cards[ns])
 
 # ─────────────────────────────────────────────────────────────
 # Phase 1: Train GTO
@@ -429,3 +533,88 @@ else:
         st.session_state.expl_hands  = expl_hands
         st.session_state.sim_done    = True
         st.rerun()
+
+# ─────────────────────────────────────────────────────────────
+# Phase 3: Play at the table
+# ─────────────────────────────────────────────────────────────
+st.divider()
+st.markdown("### Casino Table — Play vs Dealer")
+
+if not st.session_state.trained:
+    st.info("Train the model in Step 1 to unlock table play.")
+else:
+    rng_table = np.random.default_rng(int(time.time()) % (2**32 - 1))
+
+    top_a, top_b, top_c = st.columns([2, 2, 3])
+    with top_a:
+        st.metric("Your Bankroll", f"{st.session_state.play_bankroll:+d} chips")
+    with top_b:
+        st.metric("Hands Played", f"{st.session_state.play_hands}")
+    with top_c:
+        st.caption("Classic heads-up Leduc table with clean casino styling.")
+
+    if not st.session_state.play_hand_active:
+        if st.button("Deal New Hand"):
+            _new_table_hand(rng_table)
+            st.rerun()
+    else:
+        h = st.session_state.play_h
+        cards = st.session_state.play_cards
+        round_id = _bet_round(h) + 1
+        pot_scale = 2 + 2 * _raises(h) + (4 if _bet_round(h) == 1 else 0)
+
+        table_left, table_right = st.columns([3, 2])
+        with table_left:
+            board = CARD_LABELS[cards[2]] if _bet_round(h) == 1 else "?"
+            st.markdown(
+                (
+                    "<div class='casino-table'>"
+                    "<div class='casino-title'>Main Table</div>"
+                    f"<span class='chip-pill'>Round {round_id}</span>"
+                    f"<span class='chip-pill'>Pot Pressure: {pot_scale} chips</span>"
+                    "<p><strong>Your Card:</strong><span class='card-pill'>"
+                    f"{CARD_LABELS[cards[0]]}"
+                    "</span></p>"
+                    "<p><strong>Board:</strong><span class='card-pill'>"
+                    f"{board}"
+                    "</span></p>"
+                    "<p><strong>Dealer Card:</strong><span class='card-pill'>?</span></p>"
+                    "</div>"
+                ),
+                unsafe_allow_html=True,
+            )
+
+        with table_right:
+            st.markdown("<div class='dealer-log'>", unsafe_allow_html=True)
+            st.markdown("**Dealer Log**")
+            for entry in st.session_state.play_log[-6:]:
+                st.caption(entry)
+            st.markdown("</div>", unsafe_allow_html=True)
+
+        # Dealer acts automatically until it's your turn or the hand ends.
+        guard = 0
+        while st.session_state.play_hand_active and _stm(st.session_state.play_h) == 1 and guard < 6:
+            guard += 1
+            h_bot = st.session_state.play_h
+            if st.session_state.br_strategy is not None:
+                bot_action = _br_action(st.session_state.br_strategy, h_bot, rng_table)
+            else:
+                bot_action = gto_action(st.session_state.strategies, h_bot, rng_table)
+            _apply_table_action(bot_action)
+
+        if st.session_state.play_hand_active and _stm(st.session_state.play_h) == 0:
+            st.markdown("**Your move**")
+            h_user = st.session_state.play_h
+            legal = _legal_moves(h_user)
+            cols = st.columns(len(legal))
+            for idx, action in enumerate(legal):
+                if cols[idx].button(_move_label(h_user, action), key=f"user_action_{idx}_{h_user}"):
+                    _apply_table_action(action)
+                    st.rerun()
+
+        if not st.session_state.play_hand_active:
+            cards = st.session_state.play_cards
+            st.success(
+                f"Showdown: You `{CARD_LABELS[cards[0]]}` vs Dealer `{CARD_LABELS[cards[1]]}` "
+                f"(Board `{CARD_LABELS[cards[2]]}`) · Result {st.session_state.play_last_delta:+d} chips"
+            )

--- a/demos/leduc/src/showcase/classifier.py
+++ b/demos/leduc/src/showcase/classifier.py
@@ -1,0 +1,398 @@
+"""
+TiltStack — Opponent Style Classifier (Layer 2)
+================================================
+Trained on ACPC 2011 2-player No-Limit Hold'em match data (150k hands, 18 bots).
+
+Classifies a human judge's play style from their casino-table action history:
+  0  Tight/Balanced  — selective, value-bet focused
+  1  Loose-Passive   — calls wide, rarely raises (calling station)
+  2  Aggressive      — bets/raises frequently regardless of hand strength
+
+Usage
+-----
+    from classifier import OpponentClassifier, ActionTracker
+    clf = OpponentClassifier.load_or_train(hands_csv, cache_pkl)
+    tracker = ActionTracker()
+
+    # per-hand lifecycle:
+    tracker.start_hand()
+    tracker.record_action("Raise", raises_before=0, round_id=1)
+    tracker.end_hand(went_to_showdown=True)
+
+    result = clf.predict(tracker)
+    # → ("Aggressive", 0.87, array([0.04, 0.09, 0.87]))
+"""
+
+from __future__ import annotations
+
+import os
+import csv
+import pickle
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+# ── Labels & display metadata ──────────────────────────────────────────────────
+
+LABEL_NAMES  = ["Tight/Balanced", "Loose-Passive", "Aggressive"]
+LABEL_COLORS = ["#4ecdc4",        "#f5d46d",        "#ff6b6b"]
+LABEL_ICONS  = ["🎯",             "🐢",              "🔥"]
+
+# Maps each opposing profile in app.py to the label that best exploits it
+EXPLOIT_MAP: dict[str, str] = {
+    "Tight/Balanced": "Tight",        # mirror tight → GTO is fine
+    "Loose-Passive":  "Loose-Passive",
+    "Aggressive":     "Aggressive",
+}
+
+# ── Per-player style labels derived from players.csv stats ────────────────────
+#
+#   Loose-Passive : vpip ≥ 75  AND  aggression ≤ 25  AND  pfr ≤ 30
+#   Aggressive    : aggression ≥ 45  OR  (pfr ≥ 40 and vpip < 70)
+#   Tight/Balanced: everything else
+
+_PLAYER_LABELS: dict[str, int] = {
+    # 0 — Tight / Balanced
+    "Hyperborean-2011-2p-nolimit-iro": 0,
+    "Hyperborean-2011-2p-nolimit-tbr": 0,
+    "hyperborean":   0,
+    "little_rock":   0,
+    "sartre":        0,
+    "tartanian5":    0,
+    # 1 — Loose-Passive
+    "Lucky7":        1,
+    "POMPEIA":       1,
+    "Rembrant":      1,
+    "SartreNL":      1,
+    "uni_mb_poker":  1,
+    # 2 — Aggressive
+    "azure_sky":     2,
+    "dcubot":        2,
+    "hugh":          2,
+    "lucky7_12":     2,
+    "neo_poker_lab": 2,
+    "player_kappa_nl": 2,
+    "spewy_louie":   2,
+}
+
+# ── Feature extraction ─────────────────────────────────────────────────────────
+
+_FEATURES = [
+    "aggression_pct",   # ratio: raises / (raises + calls + folds)  [0-1]
+    "fold_rate",        # ratio: folds / total_voluntary            [0-1]
+    "call_rate",        # ratio: calls / total_voluntary            [0-1]
+    "raise_rate",       # ratio: raises / total_voluntary           [0-1]
+    "pfr",              # 0/1: raised in first street
+]
+# Using ratios makes features comparable between NLHE (10+ actions/hand)
+# and Leduc (4-6 actions/hand).
+
+
+def _row_features(row: dict, side: str) -> Optional[list[float]]:
+    """5-dim ratio-based feature vector for one player-side of an ACPC hand row.
+
+    All features are in [0, 1] so the distributions are comparable with
+    the shorter Leduc hands recorded by ActionTracker.
+    """
+    try:
+        raises = float(row[f"raises_{side}"])
+        calls  = float(row[f"calls_{side}"])
+        folds  = float(row[f"folds_{side}"])
+        pfr    = float(row[f"pfr_{side}"])
+        agg    = float(row[f"aggression_pct_{side}"]) / 100.0
+
+        total = raises + calls + folds
+        if total < 0.5:
+            return None   # skip hands where this player made no voluntary actions
+
+        return [
+            agg,                    # aggression_pct already a fraction
+            folds  / total,         # fold_rate
+            calls  / total,         # call_rate
+            raises / total,         # raise_rate
+            pfr,                    # preflop raise flag
+        ]
+    except (KeyError, ValueError):
+        return None
+
+
+def _build_training_data(hands_csv: str | Path) -> tuple[np.ndarray, np.ndarray]:
+    """Parse hands.csv → (X, y) arrays ready for sklearn."""
+    X: list[list[float]] = []
+    y: list[int] = []
+
+    with open(hands_csv, newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            for side, name_col in [("p1", "player1"), ("p2", "player2")]:
+                player = row.get(name_col, "").strip()
+                label  = _PLAYER_LABELS.get(player)
+                if label is None:
+                    continue
+                feat = _row_features(row, side)
+                if feat is None:
+                    continue
+                X.append(feat)
+                y.append(label)
+
+    return np.array(X, dtype=np.float32), np.array(y, dtype=np.int32)
+
+
+# ── Training ───────────────────────────────────────────────────────────────────
+
+def train_classifier(hands_csv: str | Path):
+    """Train a GradientBoostingClassifier pipeline on ACPC data."""
+    from sklearn.ensemble import GradientBoostingClassifier
+    from sklearn.preprocessing import StandardScaler
+    from sklearn.pipeline import Pipeline
+
+    X, y = _build_training_data(hands_csv)
+    counts = np.bincount(y, minlength=3)
+    print(f"[TiltStack] Training classifier on {len(X):,} samples "
+          f"(TB={counts[0]:,}  LP={counts[1]:,}  Agg={counts[2]:,})…")
+
+    pipe = Pipeline([
+        ("scaler", StandardScaler()),
+        ("clf", GradientBoostingClassifier(
+            n_estimators=200,
+            max_depth=4,
+            learning_rate=0.1,
+            subsample=0.8,
+            random_state=42,
+        )),
+    ])
+    pipe.fit(X, y)
+    acc = pipe.score(X, y)
+    print(f"[TiltStack] Classifier ready — train accuracy {acc:.3f}")
+    return pipe
+
+
+# ── Heuristic fallback (no training data available) ───────────────────────────
+
+def _heuristic_predict(fv: np.ndarray) -> tuple[str, float, np.ndarray]:
+    """Rule-based fallback classifier calibrated for ratio-based features.
+
+    fv shape: (1, 5) — [aggression_pct, fold_rate, call_rate, raise_rate, pfr]
+    All values are in [0, 1].
+    """
+    agg, fold_rate, call_rate, raise_rate, pfr = fv[0]
+
+    if agg > 0.40 or raise_rate > 0.35:
+        # Aggressive: high fraction of actions are raises
+        conf  = min(0.55 + agg * 0.35, 0.90)
+        probs = np.array([1 - conf - 0.05, 0.05, conf])
+    elif agg < 0.20 and call_rate > 0.40:
+        # Loose-Passive: calls dominate, few raises
+        conf  = min(0.55 + (1 - agg) * 0.20 + call_rate * 0.15, 0.88)
+        probs = np.array([1 - conf - 0.05, conf, 0.05])
+    elif fold_rate > 0.40 and raise_rate < 0.20:
+        # Tight: folds often, rarely raises
+        probs = np.array([0.72, 0.18, 0.10])
+    else:
+        # Balanced: unclear signal
+        probs = np.array([0.55, 0.25, 0.20])
+
+    probs = np.clip(probs, 0.01, 1.0)
+    probs /= probs.sum()
+    idx = int(np.argmax(probs))
+    return LABEL_NAMES[idx], float(probs[idx]), probs
+
+
+# ── ActionTracker ──────────────────────────────────────────────────────────────
+
+class ActionTracker:
+    """Accumulates per-hand action stats as a judge plays the casino table."""
+
+    def __init__(self) -> None:
+        self.hands: list[list[float]] = []
+        self._cur: Optional[dict] = None
+
+    # ── Hand lifecycle ─────────────────────────────────────────────────────────
+
+    def start_hand(self) -> None:
+        """Call at the start of each new casino hand."""
+        self._cur = {
+            "raises": 0, "calls": 0, "folds": 0,
+            "vpip": 0, "pfr": 0,
+            "aggression_pct": 0.0,
+            "showdown": 0,
+            "_round1_done": False,
+        }
+
+    def record_action(
+        self,
+        action_label: str,   # "Fold" | "Check" | "Call" | "Raise"
+        raises_before: int,  # raises already in the current street
+        round_id: int,       # 1 = first betting round, 2 = second
+    ) -> None:
+        """Record one of the judge's in-hand decisions."""
+        if self._cur is None:
+            self.start_hand()
+        c = self._cur
+
+        if action_label == "Raise":
+            c["raises"] += 1
+            c["vpip"]    = 1
+            if round_id == 1 and not c["_round1_done"]:
+                c["pfr"] = 1
+        elif action_label == "Call":
+            c["calls"] += 1
+            c["vpip"]   = 1
+        elif action_label == "Fold":
+            c["folds"]  = 1
+        # "Check" — passive, no counters change
+
+        if not c["_round1_done"] and round_id == 2:
+            c["_round1_done"] = True
+
+    def end_hand(self, went_to_showdown: bool) -> None:
+        """Call when the casino hand resolves.
+
+        Builds the same 5-dim ratio feature vector as _row_features() so
+        inference is in-distribution with the ACPC-trained model.
+        """
+        if self._cur is None:
+            return
+        c = self._cur
+
+        raises = float(c["raises"])
+        calls  = float(c["calls"])
+        folds  = float(c["folds"])
+        pfr    = float(c["pfr"])
+        total  = raises + calls + folds
+
+        if total < 0.5:
+            # Judge made no voluntary actions this hand — skip
+            self._cur = None
+            return
+
+        agg        = raises / total
+        fold_rate  = folds  / total
+        call_rate  = calls  / total
+        raise_rate = raises / total
+
+        self.hands.append([
+            agg,
+            fold_rate,
+            call_rate,
+            raise_rate,
+            pfr,
+        ])
+        self._cur = None
+
+    # ── Inference helpers ──────────────────────────────────────────────────────
+
+    @property
+    def n_hands(self) -> int:
+        return len(self.hands)
+
+    def feature_vector(self) -> Optional[np.ndarray]:
+        """Mean feature vector (shape 1×7) over completed hands, or None if < 3."""
+        if len(self.hands) < 3:
+            return None
+        arr = np.array(self.hands, dtype=np.float32)
+        return arr.mean(axis=0).reshape(1, -1)
+
+    def reset(self) -> None:
+        self.hands = []
+        self._cur  = None
+
+
+# ── OpponentClassifier ─────────────────────────────────────────────────────────
+
+class OpponentClassifier:
+    """Thin wrapper around a fitted sklearn pipeline (or the heuristic fallback)."""
+
+    def __init__(self, model=None) -> None:
+        self._model = model      # None → use heuristic
+
+    # ── Prediction ─────────────────────────────────────────────────────────────
+
+    def predict(
+        self, tracker: ActionTracker
+    ) -> Optional[tuple[str, float, np.ndarray]]:
+        """
+        Returns (label_name, confidence, probs) after ≥ 3 completed hands,
+        or None if not enough data yet.
+
+        Blends the heuristic (calibrated for Leduc action distributions) with
+        the ACPC-trained ML model (60/40 weight).  The heuristic anchors
+        out-of-distribution feature vectors that the NLHE-trained model
+        hasn't seen; the ML model adds signal from learned ACPC patterns.
+        """
+        fv = tracker.feature_vector()
+        if fv is None:
+            return None
+
+        # Heuristic — always stable, calibrated for Leduc feature ranges
+        _, _, h_probs = _heuristic_predict(fv)
+
+        if self._model is None:
+            probs = h_probs
+        else:
+            ml_probs = self._model.predict_proba(fv)[0]
+            # 60% heuristic, 40% ML — heuristic dominates OOD regions
+            probs = 0.60 * h_probs + 0.40 * ml_probs
+            probs /= probs.sum()
+
+        idx = int(np.argmax(probs))
+        return LABEL_NAMES[idx], float(probs[idx]), probs
+
+    # ── Loading / training ─────────────────────────────────────────────────────
+
+    @classmethod
+    def load_or_train(
+        cls,
+        hands_csv: Optional[str | Path] = None,
+        cache_pkl: Optional[str | Path] = None,
+    ) -> "OpponentClassifier":
+        """
+        Priority order:
+          1. Load cached pickle if present.
+          2. Train on hands_csv if provided and pickle not found.
+          3. Fall back to heuristic classifier.
+        """
+        # 1 — cached pickle
+        if cache_pkl and Path(cache_pkl).exists():
+            with open(cache_pkl, "rb") as fh:
+                model = pickle.load(fh)
+            print(f"[TiltStack] Loaded classifier from {cache_pkl}")
+            return cls(model)
+
+        # 2 — train from ACPC data
+        if hands_csv and Path(hands_csv).exists():
+            try:
+                model = train_classifier(hands_csv)
+                if cache_pkl:
+                    Path(cache_pkl).parent.mkdir(parents=True, exist_ok=True)
+                    with open(cache_pkl, "wb") as fh:
+                        pickle.dump(model, fh)
+                    print(f"[TiltStack] Saved classifier to {cache_pkl}")
+                return cls(model)
+            except Exception as exc:
+                print(f"[TiltStack] Training failed ({exc}), using heuristic fallback")
+
+        # 3 — heuristic fallback (always works, no deps beyond numpy)
+        print("[TiltStack] No training data found — using rule-based classifier")
+        return cls(model=None)
+
+
+# ── Convenience loader for app.py ─────────────────────────────────────────────
+
+def _resolve_paths() -> tuple[Optional[Path], Optional[Path]]:
+    """Locate hands.csv and cache.pkl relative to this file."""
+    here      = Path(__file__).parent
+    data_dir  = here.parent.parent / "data"          # demos/leduc/data/
+    hands_csv = data_dir / "hands.csv"
+    cache_pkl = data_dir / "classifier_model.pkl"
+    return (
+        hands_csv if hands_csv.exists() else None,
+        cache_pkl,
+    )
+
+
+def load_classifier() -> OpponentClassifier:
+    """One-call loader used by app.py."""
+    hands_csv, cache_pkl = _resolve_paths()
+    return OpponentClassifier.load_or_train(hands_csv, cache_pkl)


### PR DESCRIPTION
After you train (Step 1), you can deal a hand and click real moves (check/fold, call, raise) instead of only watching a bulk simulation.
You are the human at the table; “Dealer” is the bot. It uses the same math as before: best-response strategy if it exists, otherwise GTO sampling.
It tracks bankroll, hands played, a small action log, and shows J / Q / K for cards when the rules allow (board stays ? until round 2 in Leduc).
So: old app = train + charts of bots playing thousands of hands. New piece = one hand at a time that you actually play.

